### PR TITLE
Feature request: add sync-missing command to wp client.

### DIFF
--- a/inc/optimus.class.php
+++ b/inc/optimus.class.php
@@ -6,35 +6,31 @@ defined('ABSPATH') OR exit;
 
 
 /**
-* Optimus
-*
-* @since 0.0.1
-*/
+ * Optimus
+ *
+ * @since 0.0.1
+ */
 
 class Optimus
 {
 
-
     /**
-    * Pseudo-Konstruktor der Klasse
-    *
-    * @since   0.0.1
-    * @change  0.0.1
-    */
-
+     * Pseudo-Konstruktor der Klasse
+     *
+     * @since   0.0.1
+     * @change  0.0.1
+     */
     public static function instance()
     {
         new self();
     }
 
-
     /**
-    * Konstruktor der Klasse
-    *
-    * @since   0.0.1
-    * @change  1.4.6
-    */
-
+     * Konstruktor der Klasse
+     *
+     * @since   0.0.1
+     * @change  1.4.6
+     */
     public function __construct()
     {
         /* Get plugin options */
@@ -165,18 +161,15 @@ class Optimus
 
     }
 
-
-
     /**
-    * Hinzufügen der Action-Links
-    *
-    * @since   1.1.2
-    * @change  1.1.2
-    *
-    * @param   array  $data  Bereits existente Links
-    * @return  array  $data  Erweitertes Array mit Links
-    */
-
+     * Hinzufügen der Action-Links
+     *
+     * @since   1.1.2
+     * @change  1.1.2
+     *
+     * @param   array  $data  Bereits existente Links
+     * @return  array  $data  Erweitertes Array mit Links
+     */
     public static function add_action_link($data)
     {
         /* Rechte? */
@@ -201,18 +194,16 @@ class Optimus
         );
     }
 
-
     /**
-    * Hinzufügen der Meta-Informationen
-    *
-    * @since   0.0.1
-    * @change  1.1.8
-    *
-    * @param   array   $rows  Array mit Links
-    * @param   string  $file  Name des Plugins
-    * @return  array          Array mit erweitertem Link
-    */
-
+     * Hinzufügen der Meta-Informationen
+     *
+     * @since   0.0.1
+     * @change  1.1.8
+     *
+     * @param   array   $rows  Array mit Links
+     * @param   string  $file  Name des Plugins
+     * @return  array          Array mit erweitertem Link
+     */
     public static function add_row_meta($rows, $file)
     {
         /* Restliche Plugins? */
@@ -258,14 +249,12 @@ class Optimus
         return $rows;
     }
 
-
     /**
-    * Run uninstall hook
-    *
-    * @since   1.1.0
-    * @change  1.1.8
-    */
-
+     * Run uninstall hook
+     *
+     * @since   1.1.0
+     * @change  1.1.8
+     */
     public static function handle_uninstall_hook()
     {
         delete_option('optimus');
@@ -273,14 +262,12 @@ class Optimus
         delete_site_option('optimus_purchase_time');
     }
 
-
     /**
-    * Run activation hook
-    *
-    * @since   1.2.0
-    * @change  1.2.0
-    */
-
+     * Run activation hook
+     *
+     * @since   1.2.0
+     * @change  1.2.0
+     */
     public static function handle_activation_hook() {
         set_transient(
             'optimus_activation_hook_in_use',
@@ -289,14 +276,12 @@ class Optimus
         );
     }
 
-
     /**
-    * Check plugin requirements
-    *
-    * @since   1.3.1
-    * @change  1.3.1
-    */
-
+     * Check plugin requirements
+     *
+     * @since   1.3.1
+     * @change  1.3.1
+     */
     public static function optimus_requirements_check() {
         /* WordPress version check */
         if ( version_compare($GLOBALS['wp_version'], OPTIMUS_MIN_WP.'alpha', '<') ) {
@@ -325,16 +310,14 @@ class Optimus
         }
     }
 
-
     /**
-    * Return plugin options
-    *
-    * @since   1.1.2
-    * @change  1.4.0
-    *
-    * @return  array  $diff  Data pairs
-    */
-
+     * Return plugin options
+     *
+     * @since   1.1.2
+     * @change  1.4.0
+     *
+     * @return  array  $diff  Data pairs
+     */
     public static function get_options()
     {
         return wp_parse_args(
@@ -350,13 +333,12 @@ class Optimus
         );
     }
 
-
     /**
-    * Hinzufügen von JavaScript und Styles
-    *
-    * @since   1.3.8
-    * @change  1.3.8
-    */
+     * Hinzufügen von JavaScript und Styles
+     *
+     * @since   1.3.8
+     * @change  1.3.8
+     */
     public static function add_js_css()
     {
         wp_register_style(

--- a/inc/optimus_cli.class.php
+++ b/inc/optimus_cli.class.php
@@ -6,9 +6,9 @@ defined('ABSPATH') OR exit;
 
 
 /**
-* Optimus WP-CLI
-*
-*/
+ * Optimus WP-CLI
+ *
+ */
 
 class Optimus_CLI extends WP_CLI_Command
 {

--- a/inc/optimus_cli.class.php
+++ b/inc/optimus_cli.class.php
@@ -57,28 +57,28 @@ class Optimus_CLI extends WP_CLI_Command
      * Checks if all the registered files really have the optimized version.
      * Note: only works with convert to webp is enabled.
      */
-    public static function syncMissing () {
-      $options = Optimus::get_options();
-      if ($options['webp_convert'] == 0) {
-        WP_CLI::error('sync-missing command only syncs webp missing images. Looks like you don\'t have this setting enabled.', TRUE);
-      }
-
-      // Retrieves the post ids with optimized assets registered in the DB.
-      $posts = Optimus_Management::bulk_optimized_assets();
-
-      foreach ($posts as $key => $post) {
-        $assets = Optimus_Request::get_files_paths($post['ID']);
-        foreach($assets as $asset_path) {
-          if (stream_resolve_include_path($asset_path) === FALSE) {
-            $metadata = wp_get_attachment_metadata($post['ID']);
-            // Unregister the optimus flags when the file is not longer there.
-            unset($metadata['optimus']);
-            update_post_meta($post['ID'], '_wp_attachment_metadata', $metadata);
-            // Registries works at post level.
-            break;
-          }
+    public static function syncMissingWebp () {
+        $options = Optimus::get_options();
+        if ($options['webp_convert'] == 0) {
+            WP_CLI::error('sync-missing command only syncs webp missing images. Looks like you don\'t have this setting enabled.', TRUE);
         }
-      }
+
+        // Retrieves the post ids with optimized assets registered in the DB.
+        $posts = Optimus_Management::bulk_optimized_assets();
+
+        foreach ($posts as $key => $post) {
+            $assets = Optimus_Request::get_files_paths($post['ID']);
+            foreach($assets as $asset_path) {
+                if (stream_resolve_include_path($asset_path) === FALSE) {
+                    $metadata = wp_get_attachment_metadata($post['ID']);
+                    // Unregister the optimus flags when the file is not longer there.
+                    unset($metadata['optimus']);
+                    update_post_meta($post['ID'], '_wp_attachment_metadata', $metadata);
+                    // Registries works at post level.
+                    break;
+                }
+            }
+        }
     }
 
     private static function _optimize_image($img) {
@@ -130,8 +130,8 @@ class Optimus_CLI extends WP_CLI_Command
             ),
         ));
 
-        $cmd_syncmissing = function() { self::syncMissing(); };
-        WP_CLI::add_command( 'optimus sync-missing', $cmd_syncmissing, array(
+        $cmd_syncmissing = function() { self::syncMissingWebp(); };
+        WP_CLI::add_command( 'optimus webp sync', $cmd_syncmissing, array(
             'shortdesc' => 'Detects missing optimized assets.',
         ));
     }

--- a/inc/optimus_hq.class.php
+++ b/inc/optimus_hq.class.php
@@ -14,22 +14,19 @@ defined('ABSPATH') OR exit;
 class Optimus_HQ
 {
 
-
     /* Private vars */
     private static $_is_locked = NULL;
     private static $_is_unlocked = NULL;
 
-
     /**
-    * Interne Prüfung auf Optimus HQ
-    * P.S. Manipulation bringt nichts, da serverseitige Prüfung. Peace!
-    *
-    * @since   1.1.9
-    * @change  1.1.9
-    *
-    * @return  boolean  TRUE wenn Optimus HQ nicht freigeschaltet
-    */
-
+     * Interne Prüfung auf Optimus HQ
+     * P.S. Manipulation bringt nichts, da serverseitige Prüfung. Peace!
+     *
+     * @since   1.1.9
+     * @change  1.1.9
+     *
+     * @return  boolean  TRUE wenn Optimus HQ nicht freigeschaltet
+     */
     public static function is_locked()
     {
         if ( self::$_is_locked !== NULL ) {
@@ -44,17 +41,15 @@ class Optimus_HQ
         return $is_locked;
     }
 
-
     /**
-    * Interne Prüfung auf Optimus HQ
-    * P.S. Manipulation bringt nichts, da serverseitige Prüfung. Peace!
-    *
-    * @since   1.1.9
-    * @change  1.1.9
-    *
-    * @return  boolean  TRUE wenn Optimus HQ freigeschaltet
-    */
-
+     * Interne Prüfung auf Optimus HQ
+     * P.S. Manipulation bringt nichts, da serverseitige Prüfung. Peace!
+     *
+     * @since   1.1.9
+     * @change  1.1.9
+     *
+     * @return  boolean  TRUE wenn Optimus HQ freigeschaltet
+     */
     public static function is_unlocked()
     {
         if ( self::$_is_unlocked !== NULL ) {
@@ -64,17 +59,15 @@ class Optimus_HQ
         return ! self::is_locked();
     }
 
-
     /**
-    * Ablaufdatum von Optimus HQ
-    * P.S. Manipulation bringt nichts, da serverseitige Prüfung. Peace!
-    *
-    * @since   1.1.9
-    * @change  1.1.9
-    *
-    * @return  mixed  FALSE/Date  Datum im Erfolgsfall
-    */
-
+     * Ablaufdatum von Optimus HQ
+     * P.S. Manipulation bringt nichts, da serverseitige Prüfung. Peace!
+     *
+     * @since   1.1.9
+     * @change  1.1.9
+     *
+     * @return  mixed  FALSE/Date  Datum im Erfolgsfall
+     */
     public static function best_before()
     {
         /* Key exists? */
@@ -126,31 +119,27 @@ class Optimus_HQ
         return $expiration_time;
     }
 
-
     /**
-    * Return the license key
-    *
-    * @since   1.1.0
-    * @change  1.1.9
-    *
-    * @return  string  Optimus HQ Key
-    */
-
+     * Return the license key
+     *
+     * @since   1.1.0
+     * @change  1.1.9
+     *
+     * @return  string  Optimus HQ Key
+     */
     public static function get_key()
     {
         return get_site_option('optimus_key');
     }
 
-
     /**
-    * Update the license key
-    *
-    * @since   1.1.0
-    * @change  1.1.9
-    *
-    * @return  mixed  $value  Optimus HQ Key value
-    */
-
+     * Update the license key
+     *
+     * @since   1.1.0
+     * @change  1.1.9
+     *
+     * @return  mixed  $value  Optimus HQ Key value
+     */
     private static function _update_key($value)
     {
         update_site_option(
@@ -159,16 +148,14 @@ class Optimus_HQ
         );
     }
 
-
     /**
-    * Return the purchase timestamp
-    *
-    * @since   1.1.9
-    * @change  1.5.0
-    *
-    * @return  string  Optimus HQ purchase timestamp
-    */
-
+     * Return the purchase timestamp
+     *
+     * @since   1.1.9
+     * @change  1.5.0
+     *
+     * @return  string  Optimus HQ purchase timestamp
+     */
     public static function get_purchase_time($renew = false)
     {
         $purchase_time = get_site_option('optimus_purchase_time', 0);
@@ -210,14 +197,12 @@ class Optimus_HQ
         return $purchase_time;
     }
 
-
     /**
-    * Ausgabe des Eingabefeldes für den Optimus HQ Key
-    *
-    * @since   1.1.0
-    * @change  1.3.2
-    */
-
+     * Ausgabe des Eingabefeldes für den Optimus HQ Key
+     *
+     * @since   1.1.0
+     * @change  1.3.2
+     */
     public static function display_key_input()
     {
         /* Plausibility check */
@@ -267,14 +252,12 @@ class Optimus_HQ
           </style>
     <?php }
 
-
     /**
-    * Verify und store the Optimus HQ key
-    *
-    * @since   1.1.0
-    * @change  1.3.2
-    */
-
+     * Verify und store the Optimus HQ key
+     *
+     * @since   1.1.0
+     * @change  1.3.2
+     */
     public static function verify_key_input()
     {
         /* Action check */
@@ -322,15 +305,13 @@ class Optimus_HQ
         die();
     }
 
-
     /**
-    * Steuerung der Ausgabe von Admin-Notizen
-    *
-    * @since   1.1.0
-    * @change  1.2.0
-    */
-
-     public static function optimus_hq_notice()
+     * Steuerung der Ausgabe von Admin-Notizen
+     *
+     * @since   1.1.0
+     * @change  1.2.0
+     */
+    public static function optimus_hq_notice()
     {
         /* Check admin pages */
         if ( ! in_array($GLOBALS['pagenow'], array('plugins.php', 'index.php') ) ) {

--- a/inc/optimus_management.class.php
+++ b/inc/optimus_management.class.php
@@ -14,14 +14,12 @@ defined('ABSPATH') OR exit;
 class Optimus_Management
 {
 
-
     /**
-    * Bulk optimizer media
-    *
-    * @since   1.3.8
-    * @change  1.4.4
-    */
-
+     * Bulk optimizer media
+     *
+     * @since   1.3.8
+     * @change  1.4.4
+     */
     public static function bulk_optimizer_media() {
         check_admin_referer('bulk-media');
 
@@ -38,14 +36,12 @@ class Optimus_Management
         exit();
     }
 
-
     /**
-    * Add bulk optimizer page
-    *
-    * @since   1.3.8
-    * @change  1.3.8
-    */
-
+     * Add bulk optimizer page
+     *
+     * @since   1.3.8
+     * @change  1.3.8
+     */
     public static function add_bulk_optimizer_page()
     {
         /* Management page */
@@ -96,11 +92,11 @@ class Optimus_Management
     }
 
     /**
-    * Bulk optimizer collect assets
-    *
-    * @since   1.5.0
-    *
-    */
+     * Bulk optimizer collect assets
+     *
+     * @since   1.5.0
+     *
+     */
     public static function bulk_optimizer_assets() {
         global $wpdb;
 
@@ -122,8 +118,8 @@ class Optimus_Management
     }
 
     /**
-    * Gets all assets registered as already optimized.
-    */
+     * Gets all assets registered as already optimized.
+     */
     public static function bulk_optimized_assets() {
         global $wpdb;
 
@@ -145,13 +141,12 @@ class Optimus_Management
     }
 
     /**
-    * Bulk optimizer page
-    *
-    * @since   1.3.8
-    * @change  1.5.0
-    *
-    */
-
+     * Bulk optimizer page
+     *
+     * @since   1.3.8
+     * @change  1.5.0
+     *
+     */
     public static function bulk_optimizer_page() {
         $assets = self::bulk_optimizer_assets();
         $count = count($assets);

--- a/inc/optimus_media.class.php
+++ b/inc/optimus_media.class.php
@@ -14,17 +14,15 @@ defined('ABSPATH') OR exit;
 class Optimus_Media
 {
 
-
     /**
-    * Media column output
-    *
-    * @since   0.0.1
-    * @change  1.3.0
-    *
-    * @param   array  $columns  Available columns
-    * @return  array            Renewed columns
-    */
-
+     * Media column output
+     *
+     * @since   0.0.1
+     * @change  1.3.0
+     *
+     * @param   array  $columns  Available columns
+     * @return  array            Renewed columns
+     */
     public static function manage_columns($columns)
     {
         return array_merge(
@@ -35,17 +33,15 @@ class Optimus_Media
         );
     }
 
-
     /**
-    * Print Optimus values as column
-    *
-    * @since   0.0.1
-    * @change  1.3.0
-    *
-    * @param   string   $column  Column name
-    * @param   integer  $id      Current object ID
-    */
-
+     * Print Optimus values as column
+     *
+     * @since   0.0.1
+     * @change  1.3.0
+     *
+     * @param   string   $column  Column name
+     * @param   integer  $id      Current object ID
+     */
     public static function manage_column($column, $id)
     {
         /* Falsche Spalte? */
@@ -56,17 +52,15 @@ class Optimus_Media
         echo self::_column_html($id);
     }
 
-
     /**
-    * Returns the formatted column as HTML
-    *
-    * @since   0.0.1
-    * @change  1.3.0
-    *
-    * @param   intval  $id  Object ID
-    * @return  string       Column HTML
-    */
-
+     * Returns the formatted column as HTML
+     *
+     * @since   0.0.1
+     * @change  1.3.0
+     *
+     * @param   intval  $id  Object ID
+     * @return  string       Column HTML
+     */
     private static function _column_html($id)
     {
         /* Attachment metadata */
@@ -94,17 +88,15 @@ class Optimus_Media
         );
     }
 
-
     /**
-    * Specifies the CSS class depending on the amount of compressed files
-    *
-    * @since   0.0.8
-    * @change  1.3.0
-    *
-    * @param   intval  $quantity  File quantity
-    * @return  string             Optimus CSS class
-    */
-
+     * Specifies the CSS class depending on the amount of compressed files
+     *
+     * @since   0.0.8
+     * @change  1.3.0
+     *
+     * @param   intval  $quantity  File quantity
+     * @return  string             Optimus CSS class
+     */
     private static function _pie_class($quantity)
     {
         /* Init */

--- a/inc/optimus_request.class.php
+++ b/inc/optimus_request.class.php
@@ -14,25 +14,21 @@ defined('ABSPATH') OR exit;
 class Optimus_Request
 {
 
-
     /**
-    * Optimize image
-    *
-    * @var  string
-    */
-
+     * Optimize image
+     *
+     * @var  string
+     */
     private static $_remote_scheme = 'http';
 
-
     /**
-    * Image optimization post process (ajax)
-    *
-    * @since   1.3.8
-    * @change  1.4.10
-    *
-    * @return  json    $metadata    Update metadata information
-    */
-
+     * Image optimization post process (ajax)
+     *
+     * @since   1.3.8
+     * @change  1.4.10
+     *
+     * @return  json    $metadata    Update metadata information
+     */
     public static function optimize_image() {
         if (!check_ajax_referer('optimus-optimize', '_nonce', false)) {
             exit();
@@ -83,15 +79,14 @@ class Optimus_Request
     }
 
     /**
-    * Image optimization for wp retina 2x
-    *
-    * @since   1.4.6
-    * @change  1.4.7
-    *
-    * @param   integer  $attachment_id  Attachment ID
-    * @param   string  $upload_path_file_retina  Retina file path
-    */
-
+     * Image optimization for wp retina 2x
+     *
+     * @since   1.4.6
+     * @change  1.4.7
+     *
+     * @param   integer  $attachment_id  Attachment ID
+     * @param   string  $upload_path_file_retina  Retina file path
+     */
     public static function optimize_wr2x_image($attachment_id, $upload_path_file_retina) {
         // get file size
         $upload_filesize = (int)filesize($upload_path_file_retina);
@@ -134,18 +129,16 @@ class Optimus_Request
         }
     }
 
-
     /**
-    * Build optimization for a upload image including previews
-    *
-    * @since   0.0.1
-    * @change  1.4.8
-    *
-    * @param   array    $upload_data    Incoming upload information
-    * @param   integer  $attachment_id  Attachment ID
-    * @return  array    $upload_data    Renewed upload information
-    */
-
+     * Build optimization for a upload image including previews
+     *
+     * @since   0.0.1
+     * @change  1.4.8
+     *
+     * @param   array    $upload_data    Incoming upload information
+     * @param   integer  $attachment_id  Attachment ID
+     * @return  array    $upload_data    Renewed upload information
+     */
     public static function optimize_upload_images($upload_data, $attachment_id) {
         /* Get plugin options */
         $options = Optimus::get_options();
@@ -311,8 +304,8 @@ class Optimus_Request
     }
 
     /**
-    * Gets all the files paths of the optimized images.
-    */
+     * Gets all the files paths of the optimized images.
+     */
     public static function get_files_paths($post_id) {
        if ( empty ( $metadata = wp_get_attachment_metadata( $post_id ) ) ) {
          return array();
@@ -328,8 +321,8 @@ class Optimus_Request
     }
 
     /**
-    * Gets files information from the upload data.
-    */
+     * Gets files information from the upload data.
+     */
     private static function _get_files(&$upload_data, $attachment_id) {
         /* Get plugin options */
         $options = Optimus::get_options();
@@ -407,19 +400,18 @@ class Optimus_Request
     }
 
     /**
-    * Handle image actions
-    *
-    * @since   1.1.4
-    * @change  1.4.8
-    *
-    * @param   string  $file  Image file
-    * @param   array   $args  Request arguments
-    * @return  array          Request failed with an error code
-    * @return  false          An error has occurred
-    * @return  null           Empty response with 204 status code
-    * @return  intval         Response content length
-    */
-
+     * Handle image actions
+     *
+     * @since   1.1.4
+     * @change  1.4.8
+     *
+     * @param   string  $file  Image file
+     * @param   array   $args  Request arguments
+     * @return  array          Request failed with an error code
+     * @return  false          An error has occurred
+     * @return  null           Empty response with 204 status code
+     * @return  intval         Response content length
+     */
     private static function _do_image_action($file, $args)
     {
         /* Start request */
@@ -471,18 +463,16 @@ class Optimus_Request
         return $response_length;
     }
 
-
     /**
-    * Optimus API request
-    *
-    * @since   1.1.4
-    * @change  1.4.3
-    *
-    * @param   string  $file  Image file
-    * @param   array   $args  Request arguments
-    * @return  array          Response data
-    */
-
+     * Optimus API request
+     *
+     * @since   1.1.4
+     * @change  1.4.3
+     *
+     * @param   string  $file  Image file
+     * @param   array   $args  Request arguments
+     * @return  array          Response data
+     */
     private static function _do_api_request($file, $args)
     {
         return wp_safe_remote_post(
@@ -504,17 +494,15 @@ class Optimus_Request
         );
     }
 
-
     /**
-    * Get optimus task depending on $args array
-    *
-    * @since   1.1.9
-    * @change  1.1.9
-    *
-    * @param   array   $args  Array mit arguments
-    * @return  string         Current optimus task
-    */
-
+     * Get optimus task depending on $args array
+     *
+     * @since   1.1.9
+     * @change  1.1.9
+     *
+     * @param   array   $args  Array mit arguments
+     * @return  string         Current optimus task
+     */
     private static function _curl_optimus_task($args)
     {
         if ( ! empty($args['copy']) ) {
@@ -527,18 +515,16 @@ class Optimus_Request
         return 'optimize';
     }
 
-
     /**
-    * Adjustment of the file extension
-    *
-    * @since   1.1.4
-    * @change  1.3.0
-    *
-    * @param   string  $file       File path
-    * @param   string  $extension  Target extension
-    * @return  string              Renewed file path
-    */
-
+     * Adjustment of the file extension
+     *
+     * @since   1.1.4
+     * @change  1.3.0
+     *
+     * @param   string  $file       File path
+     * @param   string  $extension  Target extension
+     * @return  string              Renewed file path
+     */
     private static function _replace_file_extension($file, $extension)
     {
         return substr_replace(
@@ -549,8 +535,8 @@ class Optimus_Request
     }
 
     /**
-    * Gets the webp file path.
-    */
+     * Gets the webp file path.
+     */
     private static function _get_webp_file_path($file) {
         $options = Optimus::get_options();
         if ( $options['webp_keeporigext'] == 1 ) {
@@ -565,17 +551,15 @@ class Optimus_Request
         return $file;
     }
 
-
     /**
-    * Prüfung des erlaubten Bildtyps pro Datei
-    *
-    * @since   1.1.0
-    * @change  1.1.7
-    *
-    * @param   string   $mime_type  Mime Type
-    * @return  boolean              TRUE bei bestehender Prüfung
-    */
-
+     * Prüfung des erlaubten Bildtyps pro Datei
+     *
+     * @since   1.1.0
+     * @change  1.1.7
+     *
+     * @param   string   $mime_type  Mime Type
+     * @return  boolean              TRUE bei bestehender Prüfung
+     */
     private static function _allowed_mime_type($mime_type)
     {
         /* Leer? */
@@ -590,18 +574,16 @@ class Optimus_Request
         );
     }
 
-
     /**
-    * Prüfung der erlaubten Bildgröße pro Dateityp
-    *
-    * @since   1.1.0
-    * @change  1.1.7
-    *
-    * @param   string   $mime_type  Mime Type
-    * @param   integer  $file_size  Bild-Größe
-    * @return  boolean              TRUE bei bestehender Prüfung
-    */
-
+     * Prüfung der erlaubten Bildgröße pro Dateityp
+     *
+     * @since   1.1.0
+     * @change  1.1.7
+     *
+     * @param   string   $mime_type  Mime Type
+     * @param   integer  $file_size  Bild-Größe
+     * @return  boolean              TRUE bei bestehender Prüfung
+     */
     private static function _allowed_file_size($mime_type, $file_size)
     {
         /* Leer? */
@@ -620,16 +602,14 @@ class Optimus_Request
         return true;
     }
 
-
     /**
-    * Return Optimus quota for a plugin type
-    *
-    * @since   1.1.0
-    * @change  1.4.0
-    *
-    * @return  array  Optimus quota
-    */
-
+     * Return Optimus quota for a plugin type
+     *
+     * @since   1.1.0
+     * @change  1.4.0
+     *
+     * @return  array  Optimus quota
+     */
     private static function _get_request_quota()
     {
         /* Quota */
@@ -651,17 +631,15 @@ class Optimus_Request
         return $quota[ Optimus_HQ::is_unlocked() ];
     }
 
-
     /**
-    * Löscht erzeugte WebP-Dateien
-    *
-    * @since   1.1.4
-    * @change  1.4.6
-    *
-    * @param   string  $file  Zu löschende Original-Datei
-    * @return  string  $file  Zu löschende Original-Datei
-    */
-
+     * Löscht erzeugte WebP-Dateien
+     *
+     * @since   1.1.4
+     * @change  1.4.6
+     *
+     * @param   string  $file  Zu löschende Original-Datei
+     * @return  string  $file  Zu löschende Original-Datei
+     */
     public static function delete_converted_file($file) {
         /* Plugin options */
         $options = Optimus::get_options();
@@ -705,18 +683,16 @@ class Optimus_Request
         return $file;
     }
 
-
     /**
-    * Ermittelt die Differenz der Dateigröße
-    *
-    * @since   0.0.1
-    * @change  1.1.7
-    *
-    * @param   intval  $before  Größe vor der Optimierung in Bytes
-    * @param   intval  $after   Größe nach der Optimierung in Bytes
-    * @return  intval           Ermittelte Differenz
-    */
-
+     * Ermittelt die Differenz der Dateigröße
+     *
+     * @since   0.0.1
+     * @change  1.1.7
+     *
+     * @param   intval  $before  Größe vor der Optimierung in Bytes
+     * @param   intval  $after   Größe nach der Optimierung in Bytes
+     * @return  intval           Ermittelte Differenz
+     */
     private static function _calculate_diff_filesize($before, $after)
     {
         /* Konvertieren */

--- a/inc/optimus_request.class.php
+++ b/inc/optimus_request.class.php
@@ -314,7 +314,9 @@ class Optimus_Request
     * Gets all the files paths of the optimized images.
     */
     public static function get_files_paths($post_id) {
-       $metadata = wp_get_attachment_metadata($post_id);
+       if ( empty ( $metadata = wp_get_attachment_metadata( $post_id ) ) ) {
+         return array();
+       }
        $files = self::_get_files($metadata, $post_id);
        $post_files = array();
 

--- a/inc/optimus_request.class.php
+++ b/inc/optimus_request.class.php
@@ -320,7 +320,7 @@ class Optimus_Request
        $files = self::_get_files($metadata, $post_id);
        $post_files = array();
 
-       foreach( $files as $file ) {
+       foreach ( $files as $file ) {
            $post_files[] = self::_get_webp_file_path($file['upload_path']);
        }
 
@@ -385,7 +385,7 @@ class Optimus_Request
 
         /* Search for thumbs */
         if ( ! empty($upload_data['sizes']) ) {
-            foreach( $upload_data['sizes'] as $thumb ) {
+            foreach ( $upload_data['sizes'] as $thumb ) {
                 if ( $thumb['file'] && ( empty($thumb['mime-type']) || self::_allowed_mime_type($thumb['mime-type']) ) ) {
                     $upload_url_file = path_join($upload_url, $thumb['file']);
                     $upload_path_file = path_join($upload_path, $thumb['file']);

--- a/inc/optimus_request.class.php
+++ b/inc/optimus_request.class.php
@@ -170,7 +170,7 @@ class Optimus_Request
 
         /* Get all images from the attachment */
         $diff_filesizes = array();
-        $todo_files = self::_get_files($upload_data, $attachment_id);
+        list($todo_files, $mime_type) = self::_get_files($upload_data, $attachment_id);
 
         /* No images to process */
         if ( empty($todo_files) ) {
@@ -310,7 +310,7 @@ class Optimus_Request
        if ( empty ( $metadata = wp_get_attachment_metadata( $post_id ) ) ) {
          return array();
        }
-       $files = self::_get_files($metadata, $post_id);
+       list($files, $mime_type) = self::_get_files($metadata, $post_id);
        $post_files = array();
 
        foreach ( $files as $file ) {
@@ -322,6 +322,9 @@ class Optimus_Request
 
     /**
      * Gets files information from the upload data.
+     *
+     * @return array
+     *   Array containing the array of files and the mime type.
      */
     private static function _get_files(&$upload_data, $attachment_id) {
         /* Get plugin options */
@@ -396,7 +399,7 @@ class Optimus_Request
             $todo_files = array_reverse($todo_files);
         }
 
-        return $todo_files;
+        return array($todo_files, $mime_type);
     }
 
     /**

--- a/inc/optimus_settings.class.php
+++ b/inc/optimus_settings.class.php
@@ -14,14 +14,12 @@ defined('ABSPATH') OR exit;
 class Optimus_Settings
 {
 
-
     /**
-    * Registrierung der Settings
-    *
-    * @since   1.0.0
-    * @change  1.3.1
-    */
-
+     * Registrierung der Settings
+     *
+     * @since   1.0.0
+     * @change  1.3.1
+     */
     public static function register_settings()
     {
         register_setting(
@@ -34,17 +32,15 @@ class Optimus_Settings
         );
     }
 
-
     /**
-    * Valisierung der Optionsseite
-    *
-    * @since   1.0.0
-    * @change  1.5.0
-    *
-    * @param   array  $data  Array mit Formularwerten
-    * @return  array         Array mit geprüften Werten
-    */
-
+     * Valisierung der Optionsseite
+     *
+     * @since   1.0.0
+     * @change  1.5.0
+     *
+     * @param   array  $data  Array mit Formularwerten
+     * @return  array         Array mit geprüften Werten
+     */
     public static function validate_settings($data)
     {
         return array(
@@ -57,14 +53,12 @@ class Optimus_Settings
         );
     }
 
-
     /**
-    * Einfügen der Optionsseite
-    *
-    * @since   1.0.0
-    * @change  1.3.1
-    */
-
+     * Einfügen der Optionsseite
+     *
+     * @since   1.0.0
+     * @change  1.3.1
+     */
     public static function add_page()
     {
         $page = add_options_page(
@@ -79,16 +73,14 @@ class Optimus_Settings
         );
     }
 
-
     /**
-    * Darstellung der Optionsseite
-    *
-    * @since   1.0.0
-    * @change  1.4.0
-    *
-    * @return  void
-    */
-
+     * Darstellung der Optionsseite
+     *
+     * @since   1.0.0
+     * @change  1.4.0
+     *
+     * @return  void
+     */
     public static function settings_page()
     { ?>
         <div class="wrap">


### PR DESCRIPTION
**The problem**
Some generated images can be removed or deleted for multiple reasons. When this happen the bulk optimizer can not re-optimize it again as long are already registered as optimized and no missing images to be optimized are detected.

**Proposed solution**
Implement a method to check if all expected images to be in the file system are really there. If not present then update the DB registry to let the bulk optimizer to be able to process it.

This PR implements a new `wp` command `optimus sync-missing` that performs this operation. The feature can be exposed also to the management pages, but is not done in this PR.