### PR TITLE
Add ability to use/set  OPTIMUS_KEY programmaticly

### DIFF
--- a/inc/optimus_hq.class.php
+++ b/inc/optimus_hq.class.php
@@ -138,6 +138,10 @@ class Optimus_HQ
 
     public static function get_key()
     {
+        if (defined('OPTIMUS_KEY')) {
+            return OPTIMUS_KEY;
+        }
+
         return get_site_option('optimus_key');
     }
 


### PR DESCRIPTION
Hello 👋 @svenba and @coreykn.
I Want to contribute to keycdn/optimus.

This adds a way to programmaticly declare the OPTIMUS KEY.
eg. via envs.

The implication is that you are defining OPTIMUS_KEY with intent. 